### PR TITLE
allow to only handle custom pipelines in the config store

### DIFF
--- a/src/main/java/com/graphaware/nlp/NLPManager.java
+++ b/src/main/java/com/graphaware/nlp/NLPManager.java
@@ -130,15 +130,20 @@ public final class NLPManager {
 
     public Node annotateTextAndPersist(String text, String id, String textProcessor, String pipelineName, boolean force, boolean checkForLanguage) {
         String lang = checkTextLanguage(text, checkForLanguage);
-        String pipeline = getPipeline(pipelineName);
-        PipelineSpecification pipelineSpecification = getConfiguration().loadPipeline(pipelineName);
-        if (textProcessor == null && pipelineSpecification != null) {
-            TextProcessor tp = textProcessorsManager.getTextProcessor(pipelineSpecification.getTextProcessor());
-            AnnotatedText at = tp.annotateText(text, lang, pipelineSpecification);
+        String pipeline = null;
+        TextProcessor processor = null;
+        try {
+            pipeline = getPipeline(pipelineName);
+            processor = textProcessorsManager.retrieveTextProcessor(textProcessor, pipeline);
+        } catch (Exception e) {
+            pipeline = pipelineName;
+            PipelineSpecification pipelineSpecification = getConfiguration().loadPipeline(pipelineName);
+            processor = textProcessorsManager.getTextProcessor(pipelineSpecification.getTextProcessor());
+            AnnotatedText at = processor.annotateText(text, lang, pipelineSpecification);
 
             return processAnnotationPersist(id, text, at);
         }
-        TextProcessor processor = textProcessorsManager.retrieveTextProcessor(textProcessor, pipeline);
+
         AnnotatedText annotatedText = processor.annotateText(
                 text, pipeline, lang, null
         );

--- a/src/main/java/com/graphaware/nlp/NLPManager.java
+++ b/src/main/java/com/graphaware/nlp/NLPManager.java
@@ -131,11 +131,30 @@ public final class NLPManager {
     public Node annotateTextAndPersist(String text, String id, String textProcessor, String pipelineName, boolean force, boolean checkForLanguage) {
         String lang = checkTextLanguage(text, checkForLanguage);
         String pipeline = getPipeline(pipelineName);
+        PipelineSpecification pipelineSpecification = getConfiguration().loadPipeline(pipelineName);
+        if (textProcessor == null && pipelineSpecification != null) {
+            TextProcessor tp = textProcessorsManager.getTextProcessor(pipelineSpecification.getTextProcessor());
+            AnnotatedText at = tp.annotateText(text, lang, pipelineSpecification);
+
+            return processAnnotationPersist(id, text, at);
+        }
         TextProcessor processor = textProcessorsManager.retrieveTextProcessor(textProcessor, pipeline);
         AnnotatedText annotatedText = processor.annotateText(
                 text, pipeline, lang, null
         );
 
+        return processAnnotationPersist(id, text, annotatedText);
+    }
+
+    public Node annotateTextAndPersist(String text, String id, boolean checkForLanguage, PipelineSpecification pipelineSpecification) {
+        String lang = checkTextLanguage(text, checkForLanguage);
+        TextProcessor processor = textProcessorsManager.getTextProcessor(pipelineSpecification.getTextProcessor());
+        AnnotatedText annotatedText = processor.annotateText(text, lang, pipelineSpecification);
+
+        return processAnnotationPersist(id, text, annotatedText);
+    }
+
+    public Node processAnnotationPersist(String id, String text, AnnotatedText annotatedText) {
         String txId = String.valueOf(System.currentTimeMillis());
         Node annotatedNode = persistAnnotatedText(annotatedText, id, txId);
         TextAnnotationEvent event = new TextAnnotationEvent(annotatedNode, annotatedText, id, txId);
@@ -166,11 +185,23 @@ public final class NLPManager {
                 }
             });
         });
+
+        for (PipelineSpecification ps : configuration.loadCustomPipelines()) {
+            list.add(new PipelineInfo(
+                    ps.getName(),
+                    ps.getTextProcessor(),
+                    Collections.emptyMap(),
+                    ps.getProcessingSteps(),
+                    Integer.valueOf(String.valueOf(ps.getThreadNumber())),
+                    Arrays.asList(ps.getStopWords())
+
+            ));
+        }
+
         return list;
     }
 
     public void removePipeline(String pipeline, String processor) {
-        getTextProcessorsManager().getTextProcessor(processor).removePipeline(pipeline);
         configuration.removePipeline(pipeline, processor);
     }
 
@@ -228,7 +259,10 @@ public final class NLPManager {
     }
 
     public void addPipeline(PipelineSpecification request) {
-        textProcessorsManager.createPipeline(request);
+        // Check that the textProcessor exist !
+        if (null == request.getTextProcessor() || textProcessorsManager.getTextProcessor(request.getTextProcessor()) == null) {
+            throw new RuntimeException(String.format("Invalid text processor %s", request.getTextProcessor()));
+        }
         configuration.storeCustomPipeline(request);
     }
 

--- a/src/main/java/com/graphaware/nlp/configuration/DynamicConfiguration.java
+++ b/src/main/java/com/graphaware/nlp/configuration/DynamicConfiguration.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DynamicConfiguration {
 
@@ -125,6 +126,25 @@ public class DynamicConfiguration {
         });
 
         return list;
+    }
+
+    public PipelineSpecification loadPipeline(String name) {
+        Map<String, Object> config = getAllConfigValuesFromStore();
+        AtomicReference<PipelineSpecification> result = new AtomicReference<>();
+        config.keySet().forEach(k -> {
+            if (k.startsWith(PIPELINE_KEY_PREFIX)) {
+                try {
+                    PipelineSpecification pipelineSpecification = mapper.readValue(config.get(k).toString(), PipelineSpecification.class);
+                    if (pipelineSpecification.getName().equals(name)) {
+                        result.set(pipelineSpecification);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e.getMessage());
+                }
+            }
+        });
+
+        return result.get();
     }
 
     public void removePipeline(String name, String textProcessor) {

--- a/src/main/java/com/graphaware/nlp/dsl/request/AnnotationRequest.java
+++ b/src/main/java/com/graphaware/nlp/dsl/request/AnnotationRequest.java
@@ -15,6 +15,7 @@
  */
 package com.graphaware.nlp.dsl.request;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,12 @@ public class AnnotationRequest extends AbstractProcedureRequest {
     private boolean force;
 
     private boolean checkLanguage = true;
+
+    private List<String> annotators = new ArrayList<>();
+
+    private List<String> excludedNER = new ArrayList<>();
+
+    private List<String> excludedPOS = new ArrayList<>();
 
     public AnnotationRequest() {
 
@@ -56,7 +63,10 @@ public class AnnotationRequest extends AbstractProcedureRequest {
                 TEXT_KEY,
                 PIPELINE_KEY,
                 FORCE_KEY,
-                CHECK_LANGUAGE_KEY
+                CHECK_LANGUAGE_KEY,
+                ANNOTATORS,
+                EXCLUDED_NER,
+                EXCLUDED_POS
         );
     }
 
@@ -101,5 +111,17 @@ public class AnnotationRequest extends AbstractProcedureRequest {
 
     public boolean shouldCheckLanguage() {
         return checkLanguage;
+    }
+
+    public List<String> getAnnotators() {
+        return annotators;
+    }
+
+    public List<String> getExcludedNER() {
+        return excludedNER;
+    }
+
+    public List<String> getExcludedPOS() {
+        return excludedPOS;
     }
 }

--- a/src/main/java/com/graphaware/nlp/dsl/request/PipelineSpecification.java
+++ b/src/main/java/com/graphaware/nlp/dsl/request/PipelineSpecification.java
@@ -15,8 +15,12 @@
  */
 package com.graphaware.nlp.dsl.request;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static com.graphaware.nlp.dsl.request.RequestConstants.*;
 
 public class PipelineSpecification {
 
@@ -32,6 +36,10 @@ public class PipelineSpecification {
 
     private long threadNumber;
 
+    private List<String> excludedNER = new ArrayList<>();
+
+    private List<String> excludedPOS = new ArrayList<>();
+
     public PipelineSpecification() {
 
     }
@@ -41,6 +49,9 @@ public class PipelineSpecification {
         pipelineSpecification.setThreadNumber(map.containsKey("threadNumber") ? ((Number) map.get("threadNumber")).longValue() : DEFAULT_THREAD_NUMBER);
         if (map.containsKey("processingSteps")) {
             pipelineSpecification.setProcessingSteps((Map) map.get("processingSteps"));
+        }
+        if (map.containsKey(EXCLUDED_NER)) {
+            pipelineSpecification.setExcludedNER((List<String>) map.get(EXCLUDED_NER));
         }
 
         return pipelineSpecification;
@@ -93,5 +104,25 @@ public class PipelineSpecification {
 
     public void setProcessingSteps(Map<String, Boolean> processingSteps) {
         this.processingSteps = processingSteps;
+    }
+
+    public Map<String, Boolean> getProcessingSteps() {
+        return processingSteps;
+    }
+
+    public List<String> getExcludedNER() {
+        return excludedNER;
+    }
+
+    public void setExcludedNER(List<String> excludedNER) {
+        this.excludedNER = excludedNER;
+    }
+
+    public List<String> getExcludedPOS() {
+        return excludedPOS;
+    }
+
+    public void setExcludedPOS(List<String> excludedPOS) {
+        this.excludedPOS = excludedPOS;
     }
 }

--- a/src/main/java/com/graphaware/nlp/dsl/request/RequestConstants.java
+++ b/src/main/java/com/graphaware/nlp/dsl/request/RequestConstants.java
@@ -23,4 +23,7 @@ public final class RequestConstants {
     public static final String ENRICHER_KEY = "enricher";
     public static final String RELATIONSHIP_TYPE_KEY = "relationshipType";
     public static final String K_SIZE_KEY = "kSize";
+    public static final String ANNOTATORS = "annotators";
+    public static final String EXCLUDED_NER = "excludedNER";
+    public static final String EXCLUDED_POS = "excludedPOS";
 }

--- a/src/main/java/com/graphaware/nlp/processor/AbstractTextProcessor.java
+++ b/src/main/java/com/graphaware/nlp/processor/AbstractTextProcessor.java
@@ -22,6 +22,13 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractTextProcessor implements TextProcessor{
 
+    public static final String STEP_TOKENIZE = "tokenize";
+    public static final String STEP_NER = "ner";
+    public static final String STEP_PHRASE = "phrase";
+    public static final String STEP_DEPENDENCY = "dependency";
+    public static final String STEP_SENTIMENT = "sentiment";
+
+    public static final String DEFAULT_STOP_WORD_LIST = "start,starts,period,periods,a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,no,not,of,o,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with";
     public static final String PUNCT_REGEX_PATTERN = "^([a-z0-9]+)([-_][a-z0-9]+)*$";
 
     protected final Pattern patternCheck = Pattern.compile(PUNCT_REGEX_PATTERN, Pattern.CASE_INSENSITIVE);

--- a/src/main/java/com/graphaware/nlp/processor/TextProcessor.java
+++ b/src/main/java/com/graphaware/nlp/processor/TextProcessor.java
@@ -42,6 +42,8 @@ public interface TextProcessor {
 
     AnnotatedText annotateText(String text, String pipelineName, String lang, Map<String, String> extraParameters);
 
+    AnnotatedText annotateText(String text, String lang, PipelineSpecification pipelineSpecification);
+
     Tag annotateSentence(String text, String lang);
 
     Tag annotateTag(String text, String lang);

--- a/src/test/java/com/graphaware/nlp/persistence/AnnotatedTextPersistenceTest.java
+++ b/src/test/java/com/graphaware/nlp/persistence/AnnotatedTextPersistenceTest.java
@@ -122,8 +122,6 @@ public class AnnotatedTextPersistenceTest extends NLPIntegrationTest {
         return annotatedText;
     }
 
-
-
     private AnnotatedText createAnnotatedTextWithSameTagInSameTextWithDifferentPos() {
         AnnotatedText annotatedText = new AnnotatedText();
         AtomicInteger inc = new AtomicInteger();

--- a/src/test/java/com/graphaware/nlp/stub/StubTextProcessor.java
+++ b/src/test/java/com/graphaware/nlp/stub/StubTextProcessor.java
@@ -3,6 +3,7 @@ package com.graphaware.nlp.stub;
 import com.graphaware.nlp.annotation.NLPTextProcessor;
 import com.graphaware.nlp.domain.AnnotatedText;
 import com.graphaware.nlp.domain.Phrase;
+import com.graphaware.nlp.processor.AbstractTextProcessor;
 import com.graphaware.nlp.processor.PipelineInfo;
 import com.graphaware.nlp.domain.Sentence;
 import com.graphaware.nlp.domain.Tag;
@@ -88,6 +89,37 @@ public class StubTextProcessor implements TextProcessor {
             }
             Phrase phrase = new Phrase(stext);
             sentence.addPhraseOccurrence(0, stext.length(), phrase);
+            annotatedText.addSentence(sentence);
+            sentenceNumber++;
+        }
+
+        return annotatedText;
+    }
+
+    @Override
+    public AnnotatedText annotateText(String text, String lang, PipelineSpecification pipelineSpecification) {
+        this.lastPipelineUsed = "CORE";
+        AnnotatedText annotatedText = new AnnotatedText();
+        String[] sentencesSplit = text.split("\\.");
+        int sentenceNumber = 0;
+        for (String stext : sentencesSplit) {
+            String[] parts = stext.split(" ");
+            int pos = 0;
+            final Sentence sentence = new Sentence(stext, sentenceNumber);
+            for (String token : parts) {
+                Tag tag = new Tag(token, lang);
+                if (!pipelineSpecification.getExcludedNER().contains("test")) {
+                    tag.setNe(Collections.singletonList("test"));
+                }
+                tag.setPos(Collections.singletonList("TESTVB"));
+                int begin = pos;
+                pos += token.length() + 1;
+                sentence.addTagOccurrence(begin, pos, token, sentence.addTag(tag));
+            }
+            if (pipelineSpecification.hasProcessingStep("phrase")) {
+                Phrase phrase = new Phrase(stext);
+                sentence.addPhraseOccurrence(0, stext.length(), phrase);
+            }
             annotatedText.addSentence(sentence);
             sentenceNumber++;
         }


### PR DESCRIPTION
This PR makes the custom pipeline specifications NOT trigger a pipeline create on the TextProcessor level. Rather it stores all the informations in the KV store of the Neo4j.

Why ?

We move towards Workspaces on KnowledgeStudio, if we would ever release a cloud version and have 100 users only having 5 custom pipelines each, this would make the TextProcessor to load the pipelines into memory on startup which is completely useless.

The idea now is that TextProcessor's shall have a CORE pipeline with the full config, annotators etc.
And a new method for annotate that checks whether the processing steps shall be run in accordance with the PipelineSpecification.

PR for Stanford incoming.

NB: This PR adds also the ability to exclude NER to be set.