### PR TITLE
Unify access to the DynamicConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,12 +117,6 @@
       <version>1.19.1</version>
     </dependency>
 
-    <!--<dependency>-->
-      <!--<groupId>com.sun.jersey</groupId>-->
-      <!--<artifactId>jersey-xml</artifactId>-->
-      <!--<version>1.19.1</version>-->
-    <!--</dependency>-->
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/java/com/graphaware/nlp/NLPManager.java
+++ b/src/main/java/com/graphaware/nlp/NLPManager.java
@@ -52,31 +52,31 @@ import org.neo4j.logging.Log;
 
 import java.util.*;
 
-public class NLPManager {
+public final class NLPManager {
 
     private static final Log LOG = LoggerFactory.getLogger(NLPManager.class);
 
     private static NLPManager instance = null;
 
-    protected NLPConfiguration nlpConfiguration;
+    private NLPConfiguration nlpConfiguration;
 
-    protected TextProcessorsManager textProcessorsManager;
+    private TextProcessorsManager textProcessorsManager;
 
     protected GraphDatabaseService database;
 
     protected DynamicConfiguration configuration;
 
-    protected PersistenceRegistry persistenceRegistry;
+    private PersistenceRegistry persistenceRegistry;
 
-    protected EnrichmentRegistry enrichmentRegistry;
+    private EnrichmentRegistry enrichmentRegistry;
     
-    protected QueryBasedVectorComputation vectorComputation;
+    private QueryBasedVectorComputation vectorComputation;
 
-    protected final Map<Class, NLPExtension> extensions = new HashMap<>();
+    private final Map<Class, NLPExtension> extensions = new HashMap<>();
 
-    protected EventDispatcher eventDispatcher;
+    private EventDispatcher eventDispatcher;
 
-    protected boolean initialized = false;
+    private boolean initialized = false;
 
     protected NLPManager() {
         super();
@@ -276,7 +276,7 @@ public class NLPManager {
         return enrichmentRegistry.resolve(name);
     }
 
-    protected EnrichmentRegistry buildAndRegisterEnrichers() {
+    private EnrichmentRegistry buildAndRegisterEnrichers() {
         EnrichmentRegistry registry = new EnrichmentRegistry();
         registry.register(new ConceptNet5Enricher(database, persistenceRegistry, textProcessorsManager));
         registry.register(new MicrosoftConceptEnricher(database, persistenceRegistry, textProcessorsManager));
@@ -296,7 +296,7 @@ public class NLPManager {
         return null;
     }
 
-    protected void loadExtensions() {
+    private void loadExtensions() {
         Map<String, NLPExtension> extensionMap = ServiceLoader.loadInstances(NLPModuleExtension.class);
 
         extensionMap.keySet().forEach(k -> {
@@ -306,13 +306,13 @@ public class NLPManager {
         });
     }
 
-    protected void registerEventListeners() {
+    private void registerEventListeners() {
         extensions.values().forEach(e -> {
             e.registerEventListeners(eventDispatcher);
         });
     }
 
-    protected void registerPipelinesFromConfig() {
+    private void registerPipelinesFromConfig() {
         configuration.loadCustomPipelines().forEach(pipelineSpecification -> {
             // Check that the text processor exist, it can happen that the configuration
             // hold a reference to a processor that is not more registered, in order to avoid
@@ -324,7 +324,7 @@ public class NLPManager {
         });
     }
 
-    protected String getPipeline(String pipelineName) {
+    private String getPipeline(String pipelineName) {
         return ProcessorUtils.getPipeline(pipelineName, configuration);
     }
 

--- a/src/main/java/com/graphaware/nlp/NLPManager.java
+++ b/src/main/java/com/graphaware/nlp/NLPManager.java
@@ -94,13 +94,13 @@ public class NLPManager {
         return NLPManager.instance;
     }
 
-    public void init(GraphDatabaseService database, NLPConfiguration nlpConfiguration) {
+    public void init(GraphDatabaseService database, NLPConfiguration nlpConfiguration, DynamicConfiguration configuration) {
         if (initialized) {
             return;
         }
         this.nlpConfiguration = nlpConfiguration;
-        this.configuration = new DynamicConfiguration(database);
         this.textProcessorsManager = new TextProcessorsManager();
+        this.configuration = configuration;
         this.database = database;
         this.persistenceRegistry = new PersistenceRegistry(database);
         this.enrichmentRegistry = buildAndRegisterEnrichers();

--- a/src/main/java/com/graphaware/nlp/NLPManager.java
+++ b/src/main/java/com/graphaware/nlp/NLPManager.java
@@ -52,33 +52,33 @@ import org.neo4j.logging.Log;
 
 import java.util.*;
 
-public final class NLPManager {
+public class NLPManager {
 
     private static final Log LOG = LoggerFactory.getLogger(NLPManager.class);
 
     private static NLPManager instance = null;
 
-    private NLPConfiguration nlpConfiguration;
+    protected NLPConfiguration nlpConfiguration;
 
-    private TextProcessorsManager textProcessorsManager;
+    protected TextProcessorsManager textProcessorsManager;
 
-    private GraphDatabaseService database;
+    protected GraphDatabaseService database;
 
-    private DynamicConfiguration configuration;
+    protected DynamicConfiguration configuration;
 
-    private PersistenceRegistry persistenceRegistry;
+    protected PersistenceRegistry persistenceRegistry;
 
-    private EnrichmentRegistry enrichmentRegistry;
+    protected EnrichmentRegistry enrichmentRegistry;
     
-    private QueryBasedVectorComputation vectorComputation;
+    protected QueryBasedVectorComputation vectorComputation;
 
-    private final Map<Class, NLPExtension> extensions = new HashMap<>();
+    protected final Map<Class, NLPExtension> extensions = new HashMap<>();
 
-    private EventDispatcher eventDispatcher;
+    protected EventDispatcher eventDispatcher;
 
-    private boolean initialized = false;
+    protected boolean initialized = false;
 
-    private NLPManager() {
+    protected NLPManager() {
         super();
     }
 
@@ -237,7 +237,7 @@ public final class NLPManager {
         );
     }
 
-    private String checkTextLanguage(String text, boolean failIfUnsupported) {
+    protected String checkTextLanguage(String text, boolean failIfUnsupported) {
         LanguageManager languageManager = LanguageManager.getInstance();
         String detectedLanguage = languageManager.detectLanguage(text);
 
@@ -276,7 +276,7 @@ public final class NLPManager {
         return enrichmentRegistry.resolve(name);
     }
 
-    private EnrichmentRegistry buildAndRegisterEnrichers() {
+    protected EnrichmentRegistry buildAndRegisterEnrichers() {
         EnrichmentRegistry registry = new EnrichmentRegistry();
         registry.register(new ConceptNet5Enricher(database, persistenceRegistry, textProcessorsManager));
         registry.register(new MicrosoftConceptEnricher(database, persistenceRegistry, textProcessorsManager));
@@ -296,7 +296,7 @@ public final class NLPManager {
         return null;
     }
 
-    private void loadExtensions() {
+    protected void loadExtensions() {
         Map<String, NLPExtension> extensionMap = ServiceLoader.loadInstances(NLPModuleExtension.class);
 
         extensionMap.keySet().forEach(k -> {
@@ -306,13 +306,13 @@ public final class NLPManager {
         });
     }
 
-    private void registerEventListeners() {
+    protected void registerEventListeners() {
         extensions.values().forEach(e -> {
             e.registerEventListeners(eventDispatcher);
         });
     }
 
-    private void registerPipelinesFromConfig() {
+    protected void registerPipelinesFromConfig() {
         configuration.loadCustomPipelines().forEach(pipelineSpecification -> {
             // Check that the text processor exist, it can happen that the configuration
             // hold a reference to a processor that is not more registered, in order to avoid
@@ -324,7 +324,7 @@ public final class NLPManager {
         });
     }
 
-    private String getPipeline(String pipelineName) {
+    protected String getPipeline(String pipelineName) {
         return ProcessorUtils.getPipeline(pipelineName, configuration);
     }
 

--- a/src/main/java/com/graphaware/nlp/NLPManager.java
+++ b/src/main/java/com/graphaware/nlp/NLPManager.java
@@ -102,7 +102,7 @@ public final class NLPManager {
         this.configuration = new DynamicConfiguration(database);
         this.textProcessorsManager = new TextProcessorsManager();
         this.database = database;
-        this.persistenceRegistry = new PersistenceRegistry(database, configuration);
+        this.persistenceRegistry = new PersistenceRegistry(database);
         this.enrichmentRegistry = buildAndRegisterEnrichers();
         this.eventDispatcher = new EventDispatcher();
         this.vectorComputation = new QueryBasedVectorComputation(database);
@@ -278,8 +278,8 @@ public final class NLPManager {
 
     private EnrichmentRegistry buildAndRegisterEnrichers() {
         EnrichmentRegistry registry = new EnrichmentRegistry();
-        registry.register(new ConceptNet5Enricher(database, persistenceRegistry, configuration, textProcessorsManager));
-        registry.register(new MicrosoftConceptEnricher(database, persistenceRegistry, configuration, textProcessorsManager));
+        registry.register(new ConceptNet5Enricher(database, persistenceRegistry, textProcessorsManager));
+        registry.register(new MicrosoftConceptEnricher(database, persistenceRegistry, textProcessorsManager));
 
         return registry;
     }

--- a/src/main/java/com/graphaware/nlp/dsl/AbstractDSL.java
+++ b/src/main/java/com/graphaware/nlp/dsl/AbstractDSL.java
@@ -18,11 +18,8 @@ package com.graphaware.nlp.dsl;
 import com.graphaware.nlp.configuration.DynamicConfiguration;
 import org.codehaus.jackson.map.ObjectMapper;
 import com.graphaware.nlp.NLPManager;
-import com.graphaware.nlp.module.NLPModule;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.procedure.Context;
-
-import static com.graphaware.runtime.RuntimeRegistry.getStartedRuntime;
 
 public abstract class AbstractDSL {
 
@@ -32,11 +29,10 @@ public abstract class AbstractDSL {
     public static ObjectMapper mapper = new ObjectMapper();
 
     protected NLPManager getNLPManager() {
-        return getStartedRuntime(database).getModule(NLPModule.class).getNlpManager();
+        return NLPManager.getInstance();
     }
 
     protected DynamicConfiguration getConfiguration() {
         return getNLPManager().getConfiguration();
     }
-
 }

--- a/src/main/java/com/graphaware/nlp/dsl/AbstractDSL.java
+++ b/src/main/java/com/graphaware/nlp/dsl/AbstractDSL.java
@@ -15,6 +15,7 @@
  */
 package com.graphaware.nlp.dsl;
 
+import com.graphaware.nlp.configuration.DynamicConfiguration;
 import org.codehaus.jackson.map.ObjectMapper;
 import com.graphaware.nlp.NLPManager;
 import com.graphaware.nlp.module.NLPModule;
@@ -32,6 +33,10 @@ public abstract class AbstractDSL {
 
     protected NLPManager getNLPManager() {
         return getStartedRuntime(database).getModule(NLPModule.class).getNlpManager();
+    }
+
+    protected DynamicConfiguration getConfiguration() {
+        return getNLPManager().getConfiguration();
     }
 
 }

--- a/src/main/java/com/graphaware/nlp/enrich/AbstractEnricher.java
+++ b/src/main/java/com/graphaware/nlp/enrich/AbstractEnricher.java
@@ -16,6 +16,7 @@
 package com.graphaware.nlp.enrich;
 
 import com.graphaware.common.util.Pair;
+import com.graphaware.nlp.NLPManager;
 import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.domain.Tag;
 import com.graphaware.nlp.dsl.request.ConceptRequest;
@@ -34,12 +35,12 @@ public class AbstractEnricher {
 
     private final PersistenceRegistry persistenceRegistry;
 
-    private final DynamicConfiguration configuration;
+    private final NLPManager manager;
 
-    public AbstractEnricher(GraphDatabaseService database, PersistenceRegistry persistenceRegistry, DynamicConfiguration configuration) {
+    public AbstractEnricher(GraphDatabaseService database, PersistenceRegistry persistenceRegistry) {
         this.database = database;
         this.persistenceRegistry = persistenceRegistry;
-        this.configuration = configuration;
+        this.manager = NLPManager.getInstance();
     }
 
     protected Tag tryToAnnotate(String parentConcept, String language, TextProcessor nlpProcessor) {
@@ -92,7 +93,7 @@ public class AbstractEnricher {
     }
 
     public DynamicConfiguration getConfiguration() {
-        return configuration;
+        return manager.getConfiguration();
     }
 
     protected Persister getPersister(Class clazz) {

--- a/src/main/java/com/graphaware/nlp/enrich/conceptnet5/ConceptNet5Enricher.java
+++ b/src/main/java/com/graphaware/nlp/enrich/conceptnet5/ConceptNet5Enricher.java
@@ -51,9 +51,8 @@ public class ConceptNet5Enricher extends AbstractEnricher implements Enricher {
     public ConceptNet5Enricher(
             GraphDatabaseService database,
             PersistenceRegistry persistenceRegistry,
-            DynamicConfiguration configuration,
             TextProcessorsManager textProcessorsManager) {
-        super(database, persistenceRegistry, configuration);
+        super(database, persistenceRegistry);
         this.textProcessorsManager = textProcessorsManager;
     }
 

--- a/src/main/java/com/graphaware/nlp/enrich/microsoft/MicrosoftConceptEnricher.java
+++ b/src/main/java/com/graphaware/nlp/enrich/microsoft/MicrosoftConceptEnricher.java
@@ -38,9 +38,8 @@ public class MicrosoftConceptEnricher extends AbstractEnricher implements Enrich
     public MicrosoftConceptEnricher(
             GraphDatabaseService database,
             PersistenceRegistry persistenceRegistry,
-            DynamicConfiguration configuration,
             TextProcessorsManager textProcessorsManager) {
-        super(database, persistenceRegistry, configuration);
+        super(database, persistenceRegistry);
         this.textProcessorsManager = textProcessorsManager;
         cfg.getClasses().add(JacksonJsonProvider.class);
     }

--- a/src/main/java/com/graphaware/nlp/module/NLPModule.java
+++ b/src/main/java/com/graphaware/nlp/module/NLPModule.java
@@ -17,6 +17,7 @@ package com.graphaware.nlp.module;
 
 import com.graphaware.nlp.NLPEvents;
 import com.graphaware.nlp.NLPManager;
+import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.event.DatabaseTransactionEvent;
 import com.graphaware.runtime.module.BaseTxDrivenModule;
 import com.graphaware.runtime.module.DeliberateTransactionRollbackException;
@@ -49,7 +50,7 @@ public class NLPModule extends BaseTxDrivenModule<Void> {
     public void initialize(GraphDatabaseService database) {
         super.initialize(database);
         nlpManager = NLPManager.getInstance();
-        nlpManager.init(database, nlpMLConfiguration);
+        nlpManager.init(database, nlpMLConfiguration, new DynamicConfiguration(database));
     }
 
     public NLPConfiguration getNlpMLConfiguration() {

--- a/src/main/java/com/graphaware/nlp/persistence/PersistenceRegistry.java
+++ b/src/main/java/com/graphaware/nlp/persistence/PersistenceRegistry.java
@@ -33,12 +33,11 @@ public class PersistenceRegistry {
     private final Map<Class, Persister> registeredPersisters = new HashMap<>();
 
     public PersistenceRegistry(GraphDatabaseService databaseService) {
-        DynamicConfiguration configuration = NLPManager.getInstance().getConfiguration();
-        register(Tag.class, new TagPersister(databaseService, configuration, this));
-        register(Sentence.class, new SentencePersister(databaseService, configuration, this));
-        register(AnnotatedText.class, new AnnotatedTextPersister(databaseService, configuration, this));
-        register(Keyword.class, new KeywordPersister(databaseService, configuration, this));
-        register(VectorContainer.class, new VectorPersister(databaseService, configuration, this));
+        register(Tag.class, new TagPersister(databaseService, this));
+        register(Sentence.class, new SentencePersister(databaseService, this));
+        register(AnnotatedText.class, new AnnotatedTextPersister(databaseService, this));
+        register(Keyword.class, new KeywordPersister(databaseService, this));
+        register(VectorContainer.class, new VectorPersister(databaseService, this));
     }
 
     public final void register(Class clazz, Persister persister) {

--- a/src/main/java/com/graphaware/nlp/persistence/PersistenceRegistry.java
+++ b/src/main/java/com/graphaware/nlp/persistence/PersistenceRegistry.java
@@ -15,8 +15,6 @@
  */
 package com.graphaware.nlp.persistence;
 
-import com.graphaware.nlp.NLPManager;
-import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.domain.AnnotatedText;
 import com.graphaware.nlp.domain.Keyword;
 import com.graphaware.nlp.domain.Sentence;

--- a/src/main/java/com/graphaware/nlp/persistence/PersistenceRegistry.java
+++ b/src/main/java/com/graphaware/nlp/persistence/PersistenceRegistry.java
@@ -15,6 +15,7 @@
  */
 package com.graphaware.nlp.persistence;
 
+import com.graphaware.nlp.NLPManager;
 import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.domain.AnnotatedText;
 import com.graphaware.nlp.domain.Keyword;
@@ -31,7 +32,8 @@ public class PersistenceRegistry {
 
     private final Map<Class, Persister> registeredPersisters = new HashMap<>();
 
-    public PersistenceRegistry(GraphDatabaseService databaseService, DynamicConfiguration configuration) {
+    public PersistenceRegistry(GraphDatabaseService databaseService) {
+        DynamicConfiguration configuration = NLPManager.getInstance().getConfiguration();
         register(Tag.class, new TagPersister(databaseService, configuration, this));
         register(Sentence.class, new SentencePersister(databaseService, configuration, this));
         register(AnnotatedText.class, new AnnotatedTextPersister(databaseService, configuration, this));

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/AbstractPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/AbstractPersister.java
@@ -39,7 +39,7 @@ public abstract class AbstractPersister {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
-    public AbstractPersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
+    public AbstractPersister(GraphDatabaseService database, PersistenceRegistry registry) {
         this.database = database;
         this.registry = registry;
         this.manager = NLPManager.getInstance();

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/AbstractPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/AbstractPersister.java
@@ -15,6 +15,7 @@
  */
 package com.graphaware.nlp.persistence.persisters;
 
+import com.graphaware.nlp.NLPManager;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import com.graphaware.nlp.configuration.DynamicConfiguration;
@@ -32,7 +33,7 @@ public abstract class AbstractPersister {
 
     protected final GraphDatabaseService database;
 
-    private final DynamicConfiguration configuration;
+    protected final NLPManager manager;
 
     private final PersistenceRegistry registry;
 
@@ -40,8 +41,8 @@ public abstract class AbstractPersister {
 
     public AbstractPersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
         this.database = database;
-        this.configuration = dynamicConfiguration;
         this.registry = registry;
+        this.manager = NLPManager.getInstance();
         mapper.configure(SerializationConfig.Feature.FAIL_ON_EMPTY_BEANS, false);
         mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
@@ -51,7 +52,7 @@ public abstract class AbstractPersister {
     }
 
     protected DynamicConfiguration configuration() {
-        return configuration;
+        return manager.getConfiguration();
     }
 
     protected ObjectMapper mapper() {

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/AnnotatedTextPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/AnnotatedTextPersister.java
@@ -16,7 +16,6 @@
 package com.graphaware.nlp.persistence.persisters;
 
 import com.graphaware.common.log.LoggerFactory;
-import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.domain.AnnotatedText;
 import com.graphaware.nlp.domain.Sentence;
 import com.graphaware.nlp.persistence.PersistenceRegistry;

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/AnnotatedTextPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/AnnotatedTextPersister.java
@@ -34,8 +34,8 @@ public class AnnotatedTextPersister extends AbstractPersister implements Persist
 
     private static final Log LOG = LoggerFactory.getLogger(AnnotatedTextPersister.class);
 
-    public AnnotatedTextPersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
-        super(database, dynamicConfiguration, registry);
+    public AnnotatedTextPersister(GraphDatabaseService database, PersistenceRegistry registry) {
+        super(database, registry);
     }
     
     @Override

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/KeywordPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/KeywordPersister.java
@@ -27,8 +27,8 @@ public class KeywordPersister extends AbstractPersister implements Persister<Key
 
     private Label keywordLabel;
 
-    public KeywordPersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
-        super(database, dynamicConfiguration, registry);
+    public KeywordPersister(GraphDatabaseService database, PersistenceRegistry registry) {
+        super(database, registry);
         keywordLabel = configuration().getLabelFor(Labels.Keyword);
     }
 

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/KeywordPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/KeywordPersister.java
@@ -29,7 +29,8 @@ public class KeywordPersister extends AbstractPersister implements Persister<Key
 
     public KeywordPersister(GraphDatabaseService database, PersistenceRegistry registry) {
         super(database, registry);
-        keywordLabel = configuration().getLabelFor(Labels.Keyword);
+        keywordLabel = configuration()
+                .getLabelFor(Labels.Keyword);
     }
 
     public void setLabel(Label label) {

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/SentencePersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/SentencePersister.java
@@ -29,8 +29,8 @@ import java.util.Map;
 
 public class SentencePersister extends AbstractPersister implements Persister<Sentence> {
 
-    public SentencePersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
-        super(database, dynamicConfiguration, registry);
+    public SentencePersister(GraphDatabaseService database, PersistenceRegistry registry) {
+        super(database, registry);
     }
 
     @Override

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/TagPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/TagPersister.java
@@ -31,8 +31,8 @@ import java.util.*;
 
 public class TagPersister extends AbstractPersister implements Persister<Tag> {
 
-    public TagPersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
-        super(database, dynamicConfiguration, registry);
+    public TagPersister(GraphDatabaseService database, PersistenceRegistry registry) {
+        super(database, registry);
     }
 
     @Override

--- a/src/main/java/com/graphaware/nlp/persistence/persisters/VectorPersister.java
+++ b/src/main/java/com/graphaware/nlp/persistence/persisters/VectorPersister.java
@@ -29,8 +29,8 @@ public class VectorPersister extends AbstractPersister implements Persister<Vect
     
     private static final Logger LOG = LoggerFactory.getLogger(VectorPersister.class);
 
-    public VectorPersister(GraphDatabaseService database, DynamicConfiguration dynamicConfiguration, PersistenceRegistry registry) {
-        super(database, dynamicConfiguration, registry);
+    public VectorPersister(GraphDatabaseService database, PersistenceRegistry registry) {
+        super(database, registry);
     }
     
     @Override

--- a/src/test/java/com/graphaware/nlp/NLPIntegrationTest.java
+++ b/src/test/java/com/graphaware/nlp/NLPIntegrationTest.java
@@ -31,11 +31,15 @@ public abstract class NLPIntegrationTest extends GraphAwareIntegrationTest {
     public void setUp() throws Exception {
         resetSingleton();
         super.setUp();
+        registerRuntime();
+        keyValueStore = new GraphKeyValueStore(getDatabase());
+    }
+
+    protected void registerRuntime() {
         GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(getDatabase());
         runtime.registerModule(new NLPModule("NLP", NLPConfiguration.defaultConfiguration(), getDatabase()));
         runtime.start();
         runtime.waitUntilStarted();
-        keyValueStore = new GraphKeyValueStore(getDatabase());
     }
     
     private void resetSingleton() throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {

--- a/src/test/java/com/graphaware/nlp/enrich/conceptnet5/ConceptNet5EnricherIntegrationTest.java
+++ b/src/test/java/com/graphaware/nlp/enrich/conceptnet5/ConceptNet5EnricherIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.graphaware.nlp.enrich.conceptnet5;
 
-import com.graphaware.nlp.NLPIntegrationTest;
 import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.dsl.request.ConceptRequest;
 import com.graphaware.nlp.enrich.EnricherAbstractTest;
@@ -10,7 +9,6 @@ import com.graphaware.nlp.stub.StubTextProcessor;
 import com.graphaware.nlp.util.TestNLPGraph;
 import org.junit.Test;
 import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 
 import java.util.Arrays;
@@ -22,20 +20,18 @@ public class ConceptNet5EnricherIntegrationTest extends EnricherAbstractTest {
 
     @Test
     public void testConceptNetUrlIsConfigurable() {
-        DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, new TextProcessorsManager());
         assertEquals("http://api.conceptnet.io", enricher.getConceptNetUrl());
 
-        configuration.updateInternalSetting("CONCEPT_NET_5_URL", "http://localhost:8001");
+        getNLPManager().getConfiguration().updateInternalSetting("CONCEPT_NET_5_URL", "http://localhost:8001");
         assertEquals("http://localhost:8001", enricher.getConceptNetUrl());
     }
 
     @Test
     public void testTagsCanBeEnrichedWithConceptNet5() {
-        DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, new TextProcessorsManager());
 
         clearDb();
         executeInTransaction("CALL ga.nlp.annotate({text: 'kill cats', id: 'test-proc', checkLanguage: false})", emptyConsumer());
@@ -67,9 +63,8 @@ public class ConceptNet5EnricherIntegrationTest extends EnricherAbstractTest {
 
     @Test
     public void testRequestWithRelationshipsConstraintDoNotGetThem() {
-        DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, new TextProcessorsManager());
 
         clearDb();
         executeInTransaction("CALL ga.nlp.annotate({text: 'tension mounted as the eclipse time approached.', id: 'test-proc', checkLanguage: false})", (result -> {
@@ -101,9 +96,8 @@ public class ConceptNet5EnricherIntegrationTest extends EnricherAbstractTest {
 
     @Test
     public void testConceptEnrichmentWithRelConstraintViaProcedure() {
-        DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, new TextProcessorsManager());
 
         clearDb();
         executeInTransaction("CALL ga.nlp.annotate({text: 'tension mounted as eclipse time approached.', id: 'test-proc', checkLanguage: false})", (result -> {
@@ -122,9 +116,8 @@ public class ConceptNet5EnricherIntegrationTest extends EnricherAbstractTest {
 
     @Test
     public void testConceptWorksAfterImmediateRemoval() {
-        DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        ConceptNet5Enricher enricher = new ConceptNet5Enricher(getDatabase(), registry, new TextProcessorsManager());
 
         clearDb();
         executeInTransaction("CALL ga.nlp.annotate({text: 'tension mounted as eclipse time approached.', id: 'test-proc', checkLanguage: false})", (result -> {

--- a/src/test/java/com/graphaware/nlp/enrich/microsoft/MicrosoftEnricherTest.java
+++ b/src/test/java/com/graphaware/nlp/enrich/microsoft/MicrosoftEnricherTest.java
@@ -1,7 +1,6 @@
 package com.graphaware.nlp.enrich.microsoft;
 
 
-import com.graphaware.nlp.NLPIntegrationTest;
 import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.dsl.request.ConceptRequest;
 import com.graphaware.nlp.enrich.EnricherAbstractTest;
@@ -21,8 +20,8 @@ public class MicrosoftEnricherTest extends EnricherAbstractTest {
     @Test
     public void testCanGetConceptsFromMicrosoft() {
         DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        MicrosoftConceptEnricher enricher = new MicrosoftConceptEnricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        MicrosoftConceptEnricher enricher = new MicrosoftConceptEnricher(getDatabase(), registry, new TextProcessorsManager());
         clearDb();
         executeInTransaction("CALL ga.nlp.annotate({text: 'kill cats', id: 'test-proc', checkLanguage: false})", emptyConsumer());
 
@@ -51,8 +50,8 @@ public class MicrosoftEnricherTest extends EnricherAbstractTest {
     @Test
     public void testEnricherNameIsSetAsRelationshipProperty() {
         DynamicConfiguration configuration = new DynamicConfiguration(getDatabase());
-        PersistenceRegistry registry = new PersistenceRegistry(getDatabase(), configuration);
-        MicrosoftConceptEnricher enricher = new MicrosoftConceptEnricher(getDatabase(), registry, configuration, new TextProcessorsManager());
+        PersistenceRegistry registry = new PersistenceRegistry(getDatabase());
+        MicrosoftConceptEnricher enricher = new MicrosoftConceptEnricher(getDatabase(), registry, new TextProcessorsManager());
         clearDb();
         executeInTransaction("CALL ga.nlp.annotate({text: 'kill cats', id: 'test-proc', checkLanguage: false})", emptyConsumer());
 

--- a/src/test/java/com/graphaware/nlp/integration/AnnotationPersistenceIntegrationTest.java
+++ b/src/test/java/com/graphaware/nlp/integration/AnnotationPersistenceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.graphaware.nlp.integration;
 
 import com.graphaware.nlp.NLPIntegrationTest;
 import com.graphaware.nlp.NLPManager;
+import com.graphaware.nlp.configuration.DynamicConfiguration;
 import com.graphaware.nlp.configuration.SettingsConstants;
 import com.graphaware.nlp.domain.SentimentLabels;
 import com.graphaware.nlp.dsl.request.PipelineSpecification;
@@ -38,7 +39,7 @@ public class AnnotationPersistenceIntegrationTest extends NLPIntegrationTest {
         super.setUp();
         clearDatabase();
         manager = NLPManager.getInstance();
-        manager.init(getDatabase(), NLPConfiguration.defaultConfiguration());
+        manager.init(getDatabase(), NLPConfiguration.defaultConfiguration(), new DynamicConfiguration(getDatabase()));
     }
 
     private void resetSingleton() throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {


### PR DESCRIPTION
This makes sure that all accesses to the DynamicConfiguration are done via `NLPManager.getConfiguration()`