### PR TITLE
nlp module now migrates old specifications

### DIFF
--- a/src/main/java/com/graphaware/nlp/configuration/DynamicConfiguration.java
+++ b/src/main/java/com/graphaware/nlp/configuration/DynamicConfiguration.java
@@ -35,13 +35,13 @@ import org.codehaus.jackson.annotate.JsonTypeInfo;
 
 public class DynamicConfiguration {
 
-    protected static final String STORE_KEY = "GA__NLP__";
-    protected static final String LABEL_KEY_PREFIX = "LABEL_";
-    protected static final String RELATIONSHIP_TYPE_KEY_PREFIX = "RELATIONSHIP_";
-    protected static final String PROPERTY_KEY_PREFIX = "PROPERTY_";
-    protected static final String SETTING_KEY_PREFIX = "SETTING_";
-    protected static final String PIPELINE_KEY_PREFIX = "PIPELINE_";
-    protected static final String MODEL_KEY_PREFIX = "MODEL_";
+    public static final String STORE_KEY = "GA__NLP__";
+    public static final String LABEL_KEY_PREFIX = "LABEL_";
+    public static final String RELATIONSHIP_TYPE_KEY_PREFIX = "RELATIONSHIP_";
+    public static final String PROPERTY_KEY_PREFIX = "PROPERTY_";
+    public static final String SETTING_KEY_PREFIX = "SETTING_";
+    public static final String PIPELINE_KEY_PREFIX = "PIPELINE_";
+    public static final String MODEL_KEY_PREFIX = "MODEL_";
 
     protected final GraphDatabaseService database;
     protected final GraphKeyValueStore keyValueStore;

--- a/src/main/java/com/graphaware/nlp/configuration/MigrationHandler.java
+++ b/src/main/java/com/graphaware/nlp/configuration/MigrationHandler.java
@@ -1,0 +1,56 @@
+package com.graphaware.nlp.configuration;
+
+import com.graphaware.common.kv.GraphKeyValueStore;
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.nlp.dsl.request.PipelineSpecification;
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.logging.Log;
+
+public class MigrationHandler {
+
+    private static final Log LOG = LoggerFactory.getLogger(MigrationHandler.class);
+
+    private final GraphDatabaseService database;
+    private final DynamicConfiguration configuration;
+    private final GraphKeyValueStore graphKeyValueStore;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public MigrationHandler(GraphDatabaseService database, DynamicConfiguration configuration) {
+        this.database = database;
+        this.configuration = configuration;
+        this.graphKeyValueStore = new GraphKeyValueStore(database);
+    }
+
+    public void migrate() {
+        try (Transaction tx = database.beginTx()) {
+            graphKeyValueStore.getKeys().forEach(k -> {
+                if (isPipelineSpecification(k)) {
+                    try {
+                        doMigrate(k);
+                    } catch (Exception e) {
+                        LOG.error(e.getMessage());
+                    }
+                }
+            });
+            tx.success();
+        }
+    }
+
+    private void doMigrate(String k) throws Exception {
+        String specStr = graphKeyValueStore.get(k).toString();
+        if (!specStr.contains("\"@class\"")) {
+            PipelineSpecification pipelineSpecification = mapper.readValue(specStr, PipelineSpecification.class);
+            graphKeyValueStore.remove(k);
+            configuration.storeCustomPipeline(pipelineSpecification);
+        }
+    }
+
+    private static boolean isPipelineSpecification(String k) {
+        return k.startsWith(DynamicConfiguration.STORE_KEY + DynamicConfiguration.PIPELINE_KEY_PREFIX);
+    }
+
+
+}

--- a/src/test/java/com/graphaware/nlp/AbstractEmbeddedTest.java
+++ b/src/test/java/com/graphaware/nlp/AbstractEmbeddedTest.java
@@ -1,0 +1,25 @@
+package com.graphaware.nlp;
+
+import com.graphaware.common.kv.GraphKeyValueStore;
+import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
+import org.junit.Before;
+import org.neo4j.graphdb.Transaction;
+
+public class AbstractEmbeddedTest extends EmbeddedDatabaseIntegrationTest {
+
+    protected GraphKeyValueStore keyValueStore;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        clearDb();
+        this.keyValueStore = new GraphKeyValueStore(getDatabase());
+    }
+
+    protected void clearDb() {
+        try (Transaction tx = getDatabase().beginTx()) {
+            getDatabase().execute("MATCH (n) DETACH DELETE n");
+            tx.success();
+        }
+    }
+}

--- a/src/test/java/com/graphaware/nlp/configuration/ConfigurationMigrationTest.java
+++ b/src/test/java/com/graphaware/nlp/configuration/ConfigurationMigrationTest.java
@@ -1,0 +1,42 @@
+package com.graphaware.nlp.configuration;
+
+import com.graphaware.nlp.AbstractEmbeddedTest;
+import com.graphaware.nlp.dsl.request.PipelineSpecification;
+import com.graphaware.nlp.module.NLPConfiguration;
+import com.graphaware.nlp.module.NLPModule;
+import com.graphaware.nlp.stub.StubTextProcessor;
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+import org.neo4j.graphdb.Transaction;
+
+import static org.junit.Assert.*;
+
+public class ConfigurationMigrationTest extends AbstractEmbeddedTest {
+
+    @Test
+    public void testPipelinesCanBeMigrated() throws Exception {
+        PipelineSpecification specification = new PipelineSpecification("custom", StubTextProcessor.class.getName());
+        specification.setStopWords("hello,hihi");
+        ObjectMapper mapper = new ObjectMapper();
+        String spec = mapper.writeValueAsString(specification);
+        try (Transaction tx = getDatabase().beginTx()) {
+            keyValueStore.set(DynamicConfiguration.STORE_KEY + "PIPELINE_" + specification.getName(), spec);
+            assertFalse(spec.contains("\"@class\""));
+            tx.success();
+        }
+
+        GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(getDatabase());
+        runtime.registerModule(new NLPModule("NLP", NLPConfiguration.defaultConfiguration(), getDatabase()));
+        runtime.start();
+        runtime.waitUntilStarted();
+
+        try (Transaction tx = getDatabase().beginTx()) {
+            String s = keyValueStore.get(DynamicConfiguration.STORE_KEY + "PIPELINE_" + specification.getName()).toString();
+            assertTrue(s.contains("\"@class\""));
+            tx.success();
+        }
+    }
+
+}

--- a/src/test/java/com/graphaware/nlp/configuration/DynamicConfigurationTest.java
+++ b/src/test/java/com/graphaware/nlp/configuration/DynamicConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.graphaware.nlp.configuration;
 
+import com.graphaware.nlp.AbstractEmbeddedTest;
 import com.graphaware.nlp.workflow.input.QueryBasedWorkflowInput;
 import com.graphaware.nlp.workflow.input.WorkflowInputQueryConfiguration;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -17,7 +18,6 @@ import com.graphaware.runtime.GraphAwareRuntime;
 import com.graphaware.runtime.GraphAwareRuntimeFactory;
 import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
 import org.codehaus.jackson.map.SerializationConfig;
-import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
 
@@ -29,16 +29,7 @@ import java.util.List;
 import org.codehaus.jackson.annotate.JsonTypeInfo;
 import static org.junit.Assert.*;
 
-public class DynamicConfigurationTest extends EmbeddedDatabaseIntegrationTest {
-
-    private GraphKeyValueStore keyValueStore;
-
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        clearDb();
-        this.keyValueStore = new GraphKeyValueStore(getDatabase());
-    }
+public class DynamicConfigurationTest extends AbstractEmbeddedTest {
 
     @Test
     public void testConfigurationCanStoreAndRetrievePipelines() {
@@ -100,6 +91,7 @@ public class DynamicConfigurationTest extends EmbeddedDatabaseIntegrationTest {
             keyValueStore.set("GA__NLP__SETTING_fallbackLanguage", "en");
             tx.success();
         }
+
         GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(getDatabase());
         runtime.registerModule(new NLPModule("NLP", NLPConfiguration.defaultConfiguration(), getDatabase()));
         runtime.start();
@@ -123,18 +115,12 @@ public class DynamicConfigurationTest extends EmbeddedDatabaseIntegrationTest {
             configuration.storeWorkflowInstanceItem(workflowInput);
             tx.success();
         }
+
         GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(getDatabase());
         runtime.registerModule(new NLPModule("NLP", NLPConfiguration.defaultConfiguration(), getDatabase()));
         runtime.start();
         runtime.waitUntilStarted();
 
-    }
-
-    private void clearDb() {
-        try (Transaction tx = getDatabase().beginTx()) {
-            getDatabase().execute("MATCH (n) DETACH DELETE n");
-            tx.success();
-        }
     }
 
     private void resetSingleton() throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
@@ -167,5 +153,4 @@ public class DynamicConfigurationTest extends EmbeddedDatabaseIntegrationTest {
         assertEquals("test", info.getName());
         assertEquals("com.graphaware.nlp.workflow.task.WorkflowTask", info.getClassName());
     }
-
 }


### PR DESCRIPTION
Due to recent changes in how the pipeline spec classes are stored in the kvstore, we need a way to migrate them when neo4j starts in order to not break old databases.