### PR TITLE
get nearest neighbors of non-existence word should not throw an NPE

### DIFF
--- a/src/main/java/com/graphaware/nlp/dsl/procedure/Word2VecProcedure.java
+++ b/src/main/java/com/graphaware/nlp/dsl/procedure/Word2VecProcedure.java
@@ -93,7 +93,10 @@ public class Word2VecProcedure extends AbstractDSL {
     public Stream<NearestNeighbor> getNearestNeighbors(@Name("word") String word, @Name(value = "limit") Long limit, @Name(value = "modelName", defaultValue = "") String modelName) {
         Word2VecProcessor word2VecProcessor = (Word2VecProcessor) getNLPManager().getExtension(Word2VecProcessor.class);
 
-        return word2VecProcessor.getNearestNeighbors(word, limit.intValue(), modelName).stream().map(pair -> {
+        return word2VecProcessor.getNearestNeighbors(word, limit.intValue(), modelName)
+                .stream()
+                .filter(pair -> null != pair)
+                .map(pair -> {
             return new NearestNeighbor(pair.first().toString(), Double.valueOf(pair.second().toString()));
         });
     }

--- a/src/main/java/com/graphaware/nlp/ml/word2vec/Word2VecIndexLookup.java
+++ b/src/main/java/com/graphaware/nlp/ml/word2vec/Word2VecIndexLookup.java
@@ -113,7 +113,7 @@ public class Word2VecIndexLookup {
             TopDocs searchResult = indexSearcher.search(query, 1);
             LOG.info("Searching for '" + searchString + "'. Number of hits: " + searchResult.totalHits);
             if (searchResult.totalHits != 1) {
-                return null;
+                return new ArrayList<>();
             }
             ScoreDoc hit = searchResult.scoreDocs[0];
             Document hitDoc = indexSearcher.doc(hit.doc);


### PR DESCRIPTION
For example, running this query would fail in case a keyword would not exist in the word embeddings model :

```
MATCH (n:Document) WHERE n.id = "/data/pdf/code.pdf"
MATCH (n)-[:SUB_CONTENT]->(c)-[:HAS_ANNOTATED_TEXT]->(at)<-[r:DESCRIBES|:HAS_SUBGROUP*1..2]-(k)
UNWIND k.keywordsList AS kw
WITH kw, count(*) AS x ORDER BY x DESC LIMIT 25
CALL ga.nlp.ml.word2vec.nn(kw, 15) YIELD word RETURN word
```